### PR TITLE
feat: 메뉴 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/dishpatch/api/menu/controller/MenuController.java
+++ b/src/main/java/com/example/dishpatch/api/menu/controller/MenuController.java
@@ -2,6 +2,7 @@ package com.example.dishpatch.api.menu.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.dishpatch.api.menu.request.MenuCreateRequest;
 import com.example.dishpatch.api.menu.response.MenuCreateResponse;
+import com.example.dishpatch.api.menu.response.StoreMenuListResponse;
 import com.example.dishpatch.domain.menu.service.MenuService;
 
 import jakarta.validation.Valid;
@@ -30,5 +32,13 @@ public class MenuController {
 		// todo : SecurityFilterChain 에서 권한 체크 추가
 		MenuCreateResponse res = menuService.createMenu(storeId, req);
 		return ResponseEntity.status(HttpStatus.CREATED).body(res);
+	}
+
+	@GetMapping
+	public ResponseEntity<StoreMenuListResponse> getStoreMenus(
+		@PathVariable("storeId") Long storeId
+	) {
+		StoreMenuListResponse res = menuService.getStoreMenus(storeId);
+		return ResponseEntity.ok(res);
 	}
 }

--- a/src/main/java/com/example/dishpatch/api/menu/response/MenuOptionResponse.java
+++ b/src/main/java/com/example/dishpatch/api/menu/response/MenuOptionResponse.java
@@ -1,0 +1,15 @@
+package com.example.dishpatch.api.menu.response;
+
+import com.example.dishpatch.infra.db.menu.entity.MenuOption;
+
+public record MenuOptionResponse(
+	Long optionId,
+	String name,
+	Integer price,
+	boolean soldOut
+) {
+
+	public static MenuOptionResponse from(MenuOption option) {
+		return new MenuOptionResponse(option.getId(), option.getName(), option.getPrice(), option.isSoldOut());
+	}
+}

--- a/src/main/java/com/example/dishpatch/api/menu/response/MenuResponse.java
+++ b/src/main/java/com/example/dishpatch/api/menu/response/MenuResponse.java
@@ -1,0 +1,26 @@
+package com.example.dishpatch.api.menu.response;
+
+import java.util.List;
+
+import com.example.dishpatch.infra.db.menu.entity.Menu;
+
+public record MenuResponse(
+	Long menuId,
+	String name,
+	Integer price,
+	boolean soldOut,
+	List<MenuOptionResponse> options
+) {
+
+	public static MenuResponse from(Menu menu) {
+		return new MenuResponse(
+			menu.getId(),
+			menu.getName(),
+			menu.getPrice(),
+			menu.isSoldOut(),
+			menu.getOptions().stream()
+				.map(MenuOptionResponse::from)
+				.toList()
+		);
+	}
+}

--- a/src/main/java/com/example/dishpatch/api/menu/response/StoreMenuListResponse.java
+++ b/src/main/java/com/example/dishpatch/api/menu/response/StoreMenuListResponse.java
@@ -1,0 +1,18 @@
+package com.example.dishpatch.api.menu.response;
+
+import java.util.List;
+
+import com.example.dishpatch.infra.db.menu.entity.Menu;
+
+public record StoreMenuListResponse(
+	List<MenuResponse> menus
+) {
+
+	public static StoreMenuListResponse from(List<Menu> menus) {
+		return new StoreMenuListResponse(
+			menus.stream()
+				.map(MenuResponse::from)
+				.toList()
+		);
+	}
+}

--- a/src/main/java/com/example/dishpatch/domain/menu/exception/MenuErrorCode.java
+++ b/src/main/java/com/example/dishpatch/domain/menu/exception/MenuErrorCode.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MenuErrorCode implements ErrorCode {
 
-	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST.value(), "C001", "입력값이 올바르지 않습니다.");
+	MENU_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "M001", "존재하지 않는 메뉴입니다.");
 
 	private final int status;
 	private final String code;

--- a/src/main/java/com/example/dishpatch/domain/menu/service/MenuService.java
+++ b/src/main/java/com/example/dishpatch/domain/menu/service/MenuService.java
@@ -1,9 +1,12 @@
 package com.example.dishpatch.domain.menu.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import com.example.dishpatch.api.menu.request.MenuCreateRequest;
 import com.example.dishpatch.api.menu.response.MenuCreateResponse;
+import com.example.dishpatch.api.menu.response.StoreMenuListResponse;
 import com.example.dishpatch.infra.db.menu.entity.Menu;
 import com.example.dishpatch.infra.db.menu.repository.MenuRepository;
 import com.example.dishpatch.infra.db.store.entity.Store;
@@ -37,5 +40,15 @@ public class MenuService {
 		menuRepository.save(menu);
 
 		return MenuCreateResponse.from(menu);
+	}
+
+	public StoreMenuListResponse getStoreMenus(Long storeId) {
+		if (!storeRepository.existsById(storeId)) {
+			// todo : Store 의 ErrorCode 가 생기면 수정
+			throw new RuntimeException("존재하지 않는 가게입니다.");
+		}
+
+		List<Menu> menus = menuRepository.findAllByStoreId(storeId);
+		return StoreMenuListResponse.from(menus);
 	}
 }

--- a/src/main/java/com/example/dishpatch/infra/config/QueryDslConfig.java
+++ b/src/main/java/com/example/dishpatch/infra/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package com.example.dishpatch.infra.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Configuration
+public class QueryDslConfig {
+
+	private final EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/src/main/java/com/example/dishpatch/infra/db/menu/entity/MenuOption.java
+++ b/src/main/java/com/example/dishpatch/infra/db/menu/entity/MenuOption.java
@@ -11,7 +11,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.Getter;
 
+@Getter
 @Entity
 @Table(name = "menu_options")
 public class MenuOption extends SoftDeletableEntity {

--- a/src/main/java/com/example/dishpatch/infra/db/menu/repository/MenuQueryRepository.java
+++ b/src/main/java/com/example/dishpatch/infra/db/menu/repository/MenuQueryRepository.java
@@ -1,0 +1,10 @@
+package com.example.dishpatch.infra.db.menu.repository;
+
+import java.util.List;
+
+import com.example.dishpatch.infra.db.menu.entity.Menu;
+
+public interface MenuQueryRepository {
+
+	List<Menu> findAllByStoreId(Long storeId);
+}

--- a/src/main/java/com/example/dishpatch/infra/db/menu/repository/MenuQueryRepositoryImpl.java
+++ b/src/main/java/com/example/dishpatch/infra/db/menu/repository/MenuQueryRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.example.dishpatch.infra.db.menu.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.example.dishpatch.infra.db.menu.entity.Menu;
+import com.example.dishpatch.infra.db.menu.entity.QMenu;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class MenuQueryRepositoryImpl implements MenuQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<Menu> findAllByStoreId(Long storeId) {
+		QMenu menu = QMenu.menu;
+
+		return queryFactory
+			.selectFrom(menu)
+			.leftJoin(menu.options).fetchJoin()
+			.where(
+				menu.store.id.eq(storeId),
+				menu.deleted.isFalse()
+			)
+			.fetch();
+	}
+}

--- a/src/main/java/com/example/dishpatch/infra/db/menu/repository/MenuRepository.java
+++ b/src/main/java/com/example/dishpatch/infra/db/menu/repository/MenuRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.dishpatch.infra.db.menu.entity.Menu;
 
-public interface MenuRepository extends JpaRepository<Menu, Long> {
+public interface MenuRepository extends JpaRepository<Menu, Long>, MenuQueryRepository {
 
 }

--- a/src/test/java/com/example/dishpatch/domain/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/example/dishpatch/domain/menu/service/MenuServiceTest.java
@@ -3,6 +3,8 @@ package com.example.dishpatch.domain.menu.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -11,7 +13,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.example.dishpatch.api.menu.request.MenuCreateRequest;
 import com.example.dishpatch.api.menu.response.MenuCreateResponse;
+import com.example.dishpatch.api.menu.response.StoreMenuListResponse;
+import com.example.dishpatch.infra.db.menu.entity.Menu;
 import com.example.dishpatch.infra.db.menu.repository.MenuRepository;
+import com.example.dishpatch.infra.db.store.entity.Store;
 import com.example.dishpatch.infra.db.store.repository.StoreRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -50,6 +55,34 @@ class MenuServiceTest {
 
 		RuntimeException exception = assertThrows(RuntimeException.class,
 			() -> menuService.createMenu(storeId, menuCreateRequest));
+		assertEquals("존재하지 않는 가게입니다.", exception.getMessage());
+	}
+
+	@Test
+	void getStoreMenus_shouldSucceed() {
+		Long storeId = 1L;
+		List<Menu> menus = List.of(
+			new Menu("메뉴 이름1", 10000, "https://image.com/image_url1", false, new Store()),
+			new Menu("메뉴 이름2", 20000, "https://image.com/image_url2", true, new Store())
+		);
+
+		given(storeRepository.existsById(storeId)).willReturn(true);
+		given(menuRepository.findAllByStoreId(1L)).willReturn(menus);
+
+		StoreMenuListResponse res = menuService.getStoreMenus(storeId);
+
+		assertEquals(2, res.menus().size());
+		assertEquals("메뉴 이름1", res.menus().get(0).name());
+		assertEquals("메뉴 이름2", res.menus().get(1).name());
+	}
+
+	@Test
+	void getStoreMenus_whenStoreNotFound_shouldThrowException() {
+		Long storeId = 1L;
+
+		given(storeRepository.existsById(storeId)).willReturn(false);
+
+		RuntimeException exception = assertThrows(RuntimeException.class, () -> menuService.getStoreMenus(storeId));
 		assertEquals("존재하지 않는 가게입니다.", exception.getMessage());
 	}
 }


### PR DESCRIPTION
## 작업내용
- 메뉴 조회 기능 구현

## 변경사항
- QueryDSL 사용을 위한 설정 추가
- MenuController: GET /stores/{storeId}/menus 구현
- MenuService: getStoreMenus 로직 추가 (Store 연관 처리 포함)
- DTO: StoreMenuListResponse 생성
- MenuServiceTest: 메뉴 조회 기능 테스트 추가

## 팀원에게 전할 말
- 존재하지 않는 가게 예외는 추후에 가게 도메인에서 error code가 추가되면 수정하겠습니다.


## 체크 리스트
- [ ] 테스트 코드 작성
- [ ] 포스트맨 확인
