### PR TITLE
feat: 가게 카테고리별 조회 / 전체 조회 api

### DIFF
--- a/src/main/java/com/example/dishpatch/api/store/controller/StoreController.java
+++ b/src/main/java/com/example/dishpatch/api/store/controller/StoreController.java
@@ -1,6 +1,5 @@
 package com.example.dishpatch.api.store.controller;
 
-import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,6 +18,7 @@ import com.example.dishpatch.api.store.request.StoreUpdateRequest;
 import com.example.dishpatch.api.store.response.StoreCreateResponse;
 import com.example.dishpatch.api.store.response.StoreResponse;
 import com.example.dishpatch.domain.store.service.StoreService;
+import com.example.dishpatch.global.response.pagination.SliceResponse;
 import com.example.dishpatch.global.security.UserAuth;
 
 import jakarta.validation.Valid;
@@ -72,7 +72,7 @@ public class StoreController {
 	}
 
 	@GetMapping
-	public ResponseEntity<Slice<StoreResponse>> getStore(
+	public ResponseEntity<SliceResponse<StoreResponse>> getStore(
 		@RequestParam(required = false) Long categoryId,
 		@RequestParam(required = false) Long cursorId,
 		@RequestParam(defaultValue = "10") int size

--- a/src/main/java/com/example/dishpatch/api/store/controller/StoreController.java
+++ b/src/main/java/com/example/dishpatch/api/store/controller/StoreController.java
@@ -1,19 +1,23 @@
 package com.example.dishpatch.api.store.controller;
 
+import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.dishpatch.api.store.request.StoreCreateRequest;
 import com.example.dishpatch.api.store.request.StoreUpdateRequest;
 import com.example.dishpatch.api.store.response.StoreCreateResponse;
+import com.example.dishpatch.api.store.response.StoreResponse;
 import com.example.dishpatch.domain.store.service.StoreService;
 import com.example.dishpatch.global.security.UserAuth;
 
@@ -65,5 +69,14 @@ public class StoreController {
 		@PathVariable("storeId") Long storeId
 	) {
 		storeService.deleteStore(userAuth, storeId);
+	}
+
+	@GetMapping
+	public ResponseEntity<Slice<StoreResponse>> getStore(
+		@RequestParam(required = false) Long categoryId,
+		@RequestParam(required = false) Long cursorId,
+		@RequestParam(defaultValue = "10") int size
+	) {
+		return ResponseEntity.ok(storeService.getStore(categoryId, cursorId, size));
 	}
 }

--- a/src/main/java/com/example/dishpatch/api/store/response/StoreResponse.java
+++ b/src/main/java/com/example/dishpatch/api/store/response/StoreResponse.java
@@ -1,16 +1,22 @@
 package com.example.dishpatch.api.store.response;
 
+import com.example.dishpatch.global.response.pagination.CursorSupport;
 import com.example.dishpatch.infra.db.store.entity.Store;
 
-public record StoreResponse(
-	Long id,
-	String name,
-	String imageUrl,
-	int deliveryFee,
-	int minDeliveryPrice,
-	double rating,
-	int reviewCount
-) {
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StoreResponse implements CursorSupport {
+	Long id;
+	String name;
+	String imageUrl;
+	int deliveryFee;
+	int minDeliveryPrice;
+	double rating;
+	int reviewCount;
+
 	public static StoreResponse from(Store store) {
 		return new StoreResponse(
 			store.getId(),
@@ -21,5 +27,10 @@ public record StoreResponse(
 			store.getRating(),
 			store.getReviewCount()
 		);
+	}
+
+	@Override
+	public Long getCursorId() {
+		return id;
 	}
 }

--- a/src/main/java/com/example/dishpatch/api/store/response/StoreResponse.java
+++ b/src/main/java/com/example/dishpatch/api/store/response/StoreResponse.java
@@ -1,0 +1,25 @@
+package com.example.dishpatch.api.store.response;
+
+import com.example.dishpatch.infra.db.store.entity.Store;
+
+public record StoreResponse(
+	Long id,
+	String name,
+	String imageUrl,
+	int deliveryFee,
+	int minDeliveryPrice,
+	double rating,
+	int reviewCount
+) {
+	public static StoreResponse from(Store store) {
+		return new StoreResponse(
+			store.getId(),
+			store.getName(),
+			store.getImage(),
+			store.getDeliveryFee(),
+			store.getMinDeliveryPrice(),
+			store.getRating(),
+			store.getReviewCount()
+		);
+	}
+}

--- a/src/main/java/com/example/dishpatch/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/dishpatch/domain/store/service/StoreService.java
@@ -6,7 +6,6 @@ import static com.example.dishpatch.domain.user.exception.UserErrorCode.*;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +14,7 @@ import com.example.dishpatch.api.store.request.StoreUpdateRequest;
 import com.example.dishpatch.api.store.response.StoreCreateResponse;
 import com.example.dishpatch.api.store.response.StoreResponse;
 import com.example.dishpatch.global.exception.BizException;
+import com.example.dishpatch.global.response.pagination.SliceResponse;
 import com.example.dishpatch.global.security.UserAuth;
 import com.example.dishpatch.infra.db.cart.repository.CartRepository;
 import com.example.dishpatch.infra.db.menu.repository.MenuOptionRepository;
@@ -129,11 +129,13 @@ public class StoreService {
 		cartRepository.deleteAllByStoreId(storeId);
 	}
 
-	public Slice<StoreResponse> getStore(Long categoryId, Long cursorId, int size) {
-		categoryRepository.findById(categoryId)
-			.orElseThrow(() -> new BizException(CATEGORY_NOT_FOUND));
+	public SliceResponse<StoreResponse> getStore(Long categoryId, Long cursorId, int size) {
+		if (categoryId != null) {
+			categoryRepository.findById(categoryId)
+				.orElseThrow(() -> new BizException(CATEGORY_NOT_FOUND));
+		}
 
-		return storeRepository.findAllByCategoryId(categoryId, cursorId, size);
+		return SliceResponse.from(storeRepository.findAllByCategoryId(categoryId, cursorId, size));
 	}
 
 }

--- a/src/main/java/com/example/dishpatch/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/dishpatch/domain/store/service/StoreService.java
@@ -6,12 +6,14 @@ import static com.example.dishpatch.domain.user.exception.UserErrorCode.*;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.dishpatch.api.store.request.StoreCreateRequest;
 import com.example.dishpatch.api.store.request.StoreUpdateRequest;
 import com.example.dishpatch.api.store.response.StoreCreateResponse;
+import com.example.dishpatch.api.store.response.StoreResponse;
 import com.example.dishpatch.global.exception.BizException;
 import com.example.dishpatch.global.security.UserAuth;
 import com.example.dishpatch.infra.db.cart.repository.CartRepository;
@@ -125,6 +127,13 @@ public class StoreService {
 
 		dibRepository.deleteAllByStoreId(storeId);
 		cartRepository.deleteAllByStoreId(storeId);
+	}
+
+	public Slice<StoreResponse> getStore(Long categoryId, Long cursorId, int size) {
+		categoryRepository.findById(categoryId)
+			.orElseThrow(() -> new BizException(CATEGORY_NOT_FOUND));
+
+		return storeRepository.findAllByCategoryId(categoryId, cursorId, size);
 	}
 
 }

--- a/src/main/java/com/example/dishpatch/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/dishpatch/global/config/SecurityConfig.java
@@ -34,14 +34,14 @@ public class SecurityConfig {
 			.sessionManagement(session
 				-> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/users/signup", "/users/login")
+				.requestMatchers("/users/signup", "/users/login", "/stores")
 				.permitAll()
 				.requestMatchers("/admin/**")
 				.hasRole("ADMIN")
 				.requestMatchers("/stores/{storeId}/menus", "/stores/{storeId}/menus/{menuId}",
 					"/stores/{storeId}/menus/{menuId}", "/menus/{menuId}/options", "/menus/{menuId}/options/{optionId}",
 					"/stores/{storeId}/stats/daily", "/stores/{storeId}/stats/monthly", "/orders/{orderId}/refuse",
-					"/stores", "/stores/{storeId}", "/orders/{orderId}/update")
+					"/stores/{storeId}", "/orders/{orderId}/update")
 				.hasRole("CEO")
 				.requestMatchers(HttpMethod.POST, "/ceoReviews/{reviewId}")
 				.hasRole("CEO")
@@ -51,6 +51,8 @@ public class SecurityConfig {
 				.hasAnyRole("USER", "ADMIN")
 				.requestMatchers(HttpMethod.DELETE, "/ceoReviews/{ceoReviewId}", "/stores/{storeId}")
 				.hasAnyRole("CEO", "ADMIN")
+				.requestMatchers(HttpMethod.POST, "/stores")
+				.hasRole("CEO")
 				.anyRequest()
 				.authenticated()
 			)

--- a/src/main/java/com/example/dishpatch/global/response/pagination/CursorSupport.java
+++ b/src/main/java/com/example/dishpatch/global/response/pagination/CursorSupport.java
@@ -1,0 +1,5 @@
+package com.example.dishpatch.global.response.pagination;
+
+public interface CursorSupport {
+	Long getCursorId();
+}

--- a/src/main/java/com/example/dishpatch/global/response/pagination/SliceResponse.java
+++ b/src/main/java/com/example/dishpatch/global/response/pagination/SliceResponse.java
@@ -1,0 +1,28 @@
+package com.example.dishpatch.global.response.pagination;
+
+import java.util.List;
+
+import org.springframework.data.domain.Slice;
+
+public record SliceResponse<T>(
+	List<T> content,
+	boolean hasNext,
+	Long nextCursorId,
+	int size,
+	int contentSize,
+	boolean empty
+) {
+	public static <T extends CursorSupport> SliceResponse<T> from(Slice<T> slice) {
+		List<T> content = slice.getContent();
+		Long nextCursorId = content.isEmpty() ? null : content.get(content.size() - 1).getCursorId();
+
+		return new SliceResponse<>(
+			content,
+			slice.hasNext(),
+			nextCursorId,
+			slice.getSize(),
+			content.size(),
+			slice.isEmpty()
+		);
+	}
+}

--- a/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepository.java
+++ b/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepository.java
@@ -1,0 +1,9 @@
+package com.example.dishpatch.infra.db.store.repository;
+
+import org.springframework.data.domain.Slice;
+
+import com.example.dishpatch.api.store.response.StoreResponse;
+
+public interface StoreQueryRepository {
+	Slice<StoreResponse> findAllByCategoryId(Long categoryId, Long cursorId, int size);
+}

--- a/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepositoryImpl.java
+++ b/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepositoryImpl.java
@@ -40,7 +40,7 @@ public class StoreQueryRepositoryImpl implements StoreQueryRepository {
 				qStore.deletedDate.isNull(),
 				ltCursorId(cursorId)
 			)
-			.orderBy(qStore.id.desc())
+			.orderBy(qStore.isAdvertised.desc(), qStore.id.desc())
 			.limit(size + 1)
 			.fetch();
 
@@ -54,7 +54,7 @@ public class StoreQueryRepositoryImpl implements StoreQueryRepository {
 	}
 
 	private BooleanExpression categoryEq(Long categoryId) {
-		return categoryId != null ? null : qStore.category.id.eq(categoryId);
+		return categoryId == null ? null : qStore.category.id.eq(categoryId);
 	}
 
 	private BooleanExpression ltCursorId(Long cursorId) {

--- a/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepositoryImpl.java
+++ b/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepositoryImpl.java
@@ -1,0 +1,64 @@
+package com.example.dishpatch.infra.db.store.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import com.example.dishpatch.api.store.response.StoreResponse;
+import com.example.dishpatch.infra.db.store.entity.QStore;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class StoreQueryRepositoryImpl implements StoreQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+	private final QStore qStore = QStore.store;
+
+	@Override
+	public Slice<StoreResponse> findAllByCategoryId(Long categoryId, Long cursorId, int size) {
+		List<StoreResponse> stores = queryFactory
+			.select(Projections.constructor(StoreResponse.class,
+				qStore.id,
+				qStore.name,
+				qStore.image,
+				qStore.deliveryFee,
+				qStore.minDeliveryPrice,
+				qStore.rating,
+				qStore.reviewCount
+			))
+			.from(qStore)
+			.where(
+				categoryEq(categoryId),
+				qStore.deletedDate.isNull(),
+				ltCursorId(cursorId)
+			)
+			.orderBy(qStore.id.desc())
+			.limit(size + 1)
+			.fetch();
+
+		boolean hasNext = stores.size() > size;
+
+		if (hasNext) {
+			stores.remove(size);
+		}
+
+		return new SliceImpl<>(stores, PageRequest.of(0, size), hasNext);
+	}
+
+	private BooleanExpression categoryEq(Long categoryId) {
+		return categoryId != null ? null : qStore.category.id.eq(categoryId);
+	}
+
+	private BooleanExpression ltCursorId(Long cursorId) {
+		return cursorId == null ? null : qStore.id.lt(cursorId);
+	}
+
+}

--- a/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreRepository.java
+++ b/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreRepository.java
@@ -1,7 +1,7 @@
 package com.example.dishpatch.infra.db.store.repository;
 
-import java.util.Optional;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,16 +10,14 @@ import org.springframework.data.repository.query.Param;
 import com.example.dishpatch.infra.db.store.entity.Store;
 import com.example.dishpatch.infra.db.user.entity.User;
 
-import com.example.dishpatch.infra.db.store.entity.Store;
-
-public interface StoreRepository extends JpaRepository<Store, Long> {
+public interface StoreRepository extends JpaRepository<Store, Long>, StoreQueryRepository {
 	int countByUserIdAndDeletedDateIsNull(Long userId);
-  
+
 	Optional<Store> findByIdAndDeletedDateIsNull(Long storeId);
 
 	boolean existsByIdAndDeletedDateIsNull(Long storeId);
 
 	@Query("SELECT s.id FROM Store s WHERE s.user = :user")
 	List<Long> findIdByUser(@Param("user") User user);
-  
+
 }


### PR DESCRIPTION
## 작업내용
- 가게 카테고리별 조회 / 전체 조회 api
- 무한스크롤 구현을 위해 QueryDSL 사용해서 커서 기반 페이지네이션을 적용했습니다.
- 커서 기반 응답 DTO를 따로 만들어서 /global/response/pagination 패키지에 넣었습니다.

## 변경사항
- SecurityFilterChain에서 GET /stores는 permitAll()로 수정했습니다.


## 팀원에게 전할 말


## 체크 리스트
- [ ] 테스트 코드 작성
- [x] 포스트맨 확인
