### PR TITLE
feat: 추천 가게 조회

### DIFF
--- a/src/main/java/com/example/dishpatch/api/store/controller/StoreController.java
+++ b/src/main/java/com/example/dishpatch/api/store/controller/StoreController.java
@@ -20,6 +20,7 @@ import com.example.dishpatch.api.store.response.StoreResponse;
 import com.example.dishpatch.domain.store.service.StoreService;
 import com.example.dishpatch.global.response.pagination.SliceResponse;
 import com.example.dishpatch.global.security.UserAuth;
+import com.example.dishpatch.infra.db.store.enums.SortType;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -73,7 +74,7 @@ public class StoreController {
 
 	@GetMapping
 	public ResponseEntity<SliceResponse<StoreResponse>> getStore(
-		@RequestParam(required = false) String sortType,  // dib, rating, orderCount
+		@RequestParam(required = false) SortType sortType,  // dib, rating, orderCount
 		@RequestParam(required = false) Long categoryId,
 		@RequestParam(required = false) Long cursorId,
 		@RequestParam(defaultValue = "10") int size

--- a/src/main/java/com/example/dishpatch/api/store/controller/StoreController.java
+++ b/src/main/java/com/example/dishpatch/api/store/controller/StoreController.java
@@ -73,10 +73,12 @@ public class StoreController {
 
 	@GetMapping
 	public ResponseEntity<SliceResponse<StoreResponse>> getStore(
+		@RequestParam(required = false) String sortType,  // dib, rating, orderCount
 		@RequestParam(required = false) Long categoryId,
 		@RequestParam(required = false) Long cursorId,
 		@RequestParam(defaultValue = "10") int size
 	) {
-		return ResponseEntity.ok(storeService.getStore(categoryId, cursorId, size));
+		return ResponseEntity.ok(storeService.getStore(sortType, categoryId, cursorId, size));
 	}
+
 }

--- a/src/main/java/com/example/dishpatch/api/store/response/StoreResponse.java
+++ b/src/main/java/com/example/dishpatch/api/store/response/StoreResponse.java
@@ -33,4 +33,5 @@ public class StoreResponse implements CursorSupport {
 	public Long getCursorId() {
 		return id;
 	}
+
 }

--- a/src/main/java/com/example/dishpatch/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/dishpatch/domain/store/service/StoreService.java
@@ -24,6 +24,7 @@ import com.example.dishpatch.infra.db.review.repository.ReviewRepository;
 import com.example.dishpatch.infra.db.store.entity.Category;
 import com.example.dishpatch.infra.db.store.entity.Dib;
 import com.example.dishpatch.infra.db.store.entity.Store;
+import com.example.dishpatch.infra.db.store.enums.SortType;
 import com.example.dishpatch.infra.db.store.repository.CategoryRepository;
 import com.example.dishpatch.infra.db.store.repository.DibRepository;
 import com.example.dishpatch.infra.db.store.repository.StoreRepository;
@@ -133,7 +134,7 @@ public class StoreService {
 	}
 
 	@Transactional(readOnly = true)
-	public SliceResponse<StoreResponse> getStore(String sortType, Long categoryId, Long cursorId, int size) {
+	public SliceResponse<StoreResponse> getStore(SortType sortType, Long categoryId, Long cursorId, int size) {
 		if (categoryId != null) {
 			categoryRepository.findById(categoryId)
 				.orElseThrow(() -> new BizException(CATEGORY_NOT_FOUND));

--- a/src/main/java/com/example/dishpatch/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/dishpatch/domain/store/service/StoreService.java
@@ -46,6 +46,7 @@ public class StoreService {
 	private final MenuOptionRepository menuOptionRepository;
 	private final CartRepository cartRepository;
 
+	@Transactional
 	public StoreCreateResponse createStore(UserAuth userAuth, StoreCreateRequest request) {
 		User user = userRepository.findByIdAndStatus(userAuth.getId(), UserStatus.ACTIVE)
 			.orElseThrow(() -> new BizException(INVALID_ID));
@@ -80,12 +81,14 @@ public class StoreService {
 		store.update(request, category);
 	}
 
+	@Transactional
 	public void dibStore(UserAuth userAuth, Long storeId) {
 		User user = userRepository.findByIdAndStatus(userAuth.getId(), UserStatus.ACTIVE)
 			.orElseThrow(() -> new BizException(INVALID_ID));
 
 		Store store = storeRepository.findByIdAndDeletedDateIsNull(storeId)
 			.orElseThrow(() -> new BizException(STORE_NOT_FOUND));
+		store.plusDib();
 
 		if (dibRepository.existsByUserIdAndStoreId(userAuth.getId(), storeId)) {
 			throw new BizException(ALREADY_DIB_STORE);
@@ -98,9 +101,9 @@ public class StoreService {
 
 	@Transactional
 	public void undibStore(UserAuth userAuth, Long storeId) {
-		if (!storeRepository.existsByIdAndDeletedDateIsNull(storeId)) {
-			throw new BizException(STORE_NOT_FOUND);
-		}
+		Store store = storeRepository.findByIdAndDeletedDateIsNull(storeId)
+			.orElseThrow(() -> new BizException(STORE_NOT_FOUND));
+		store.minusDib();
 
 		Dib dib = dibRepository.findByUserIdAndStoreId(userAuth.getId(), storeId)
 			.orElseThrow(() -> new BizException(UNDIB_STORE));
@@ -129,6 +132,7 @@ public class StoreService {
 		cartRepository.deleteAllByStoreId(storeId);
 	}
 
+	@Transactional(readOnly = true)
 	public SliceResponse<StoreResponse> getStore(String sortType, Long categoryId, Long cursorId, int size) {
 		if (categoryId != null) {
 			categoryRepository.findById(categoryId)

--- a/src/main/java/com/example/dishpatch/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/dishpatch/domain/store/service/StoreService.java
@@ -129,13 +129,13 @@ public class StoreService {
 		cartRepository.deleteAllByStoreId(storeId);
 	}
 
-	public SliceResponse<StoreResponse> getStore(Long categoryId, Long cursorId, int size) {
+	public SliceResponse<StoreResponse> getStore(String sortType, Long categoryId, Long cursorId, int size) {
 		if (categoryId != null) {
 			categoryRepository.findById(categoryId)
 				.orElseThrow(() -> new BizException(CATEGORY_NOT_FOUND));
 		}
 
-		return SliceResponse.from(storeRepository.findAllByCategoryId(categoryId, cursorId, size));
+		return SliceResponse.from(storeRepository.findAllByCategoryId(sortType, categoryId, cursorId, size));
 	}
 
 }

--- a/src/main/java/com/example/dishpatch/infra/db/store/entity/Store.java
+++ b/src/main/java/com/example/dishpatch/infra/db/store/entity/Store.java
@@ -118,4 +118,14 @@ public class Store extends SoftDeletableEntity {
 		this.closeTime = request.getCloseTime();
 		this.category = category;
 	}
+
+	public void plusDib() {
+		this.dibCount++;
+	}
+
+	public void minusDib() {
+		if (dibCount > 0) {
+			this.dibCount--;
+		}
+	}
 }

--- a/src/main/java/com/example/dishpatch/infra/db/store/enums/SortType.java
+++ b/src/main/java/com/example/dishpatch/infra/db/store/enums/SortType.java
@@ -1,0 +1,5 @@
+package com.example.dishpatch.infra.db.store.enums;
+
+public enum SortType {
+	DIB, RATING, ORDER_COUNT
+}

--- a/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepository.java
+++ b/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.domain.Slice;
 import com.example.dishpatch.api.store.response.StoreResponse;
 
 public interface StoreQueryRepository {
-	Slice<StoreResponse> findAllByCategoryId(Long categoryId, Long cursorId, int size);
+	Slice<StoreResponse> findAllByCategoryId(String sortType, Long categoryId, Long cursorId, int size);
 }

--- a/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepository.java
+++ b/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepository.java
@@ -3,7 +3,8 @@ package com.example.dishpatch.infra.db.store.repository;
 import org.springframework.data.domain.Slice;
 
 import com.example.dishpatch.api.store.response.StoreResponse;
+import com.example.dishpatch.infra.db.store.enums.SortType;
 
 public interface StoreQueryRepository {
-	Slice<StoreResponse> findAllByCategoryId(String sortType, Long categoryId, Long cursorId, int size);
+	Slice<StoreResponse> findAllByCategoryId(SortType sortType, Long categoryId, Long cursorId, int size);
 }

--- a/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepositoryImpl.java
+++ b/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepositoryImpl.java
@@ -12,6 +12,7 @@ import com.example.dishpatch.api.store.response.StoreResponse;
 import com.example.dishpatch.infra.db.order.entity.OrderStatus;
 import com.example.dishpatch.infra.db.order.entity.QOrder;
 import com.example.dishpatch.infra.db.store.entity.QStore;
+import com.example.dishpatch.infra.db.store.enums.SortType;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -28,10 +29,10 @@ public class StoreQueryRepositoryImpl implements StoreQueryRepository {
 	private final QStore qStore = QStore.store;
 
 	@Override
-	public Slice<StoreResponse> findAllByCategoryId(String sortType, Long categoryId, Long cursorId, int size) {
+	public Slice<StoreResponse> findAllByCategoryId(SortType sortType, Long categoryId, Long cursorId, int size) {
 		List<StoreResponse> stores;
 
-		if ("orderCount".equals(sortType)) {
+		if ("ORDER_COUNT".equals(sortType.name())) {
 			QOrder qOrder = QOrder.order;
 
 			stores = queryFactory
@@ -49,8 +50,7 @@ public class StoreQueryRepositoryImpl implements StoreQueryRepository {
 				.where(
 					categoryEq(categoryId),
 					qStore.deletedDate.isNull(),
-					ltCursorId(cursorId),
-					qOrder.status.eq(OrderStatus.FINISHED)
+					ltCursorId(cursorId)
 				)
 				.groupBy(qStore.id)
 				.orderBy(getOrderCountSortOrders().toArray(OrderSpecifier[]::new))
@@ -88,15 +88,15 @@ public class StoreQueryRepositoryImpl implements StoreQueryRepository {
 		return new SliceImpl<>(stores, PageRequest.of(0, size), hasNext);
 	}
 
-	private List<OrderSpecifier<?>> getSortOrders(String sortType) {
+	private List<OrderSpecifier<?>> getSortOrders(SortType sortType) {
 		List<OrderSpecifier<?>> orders = new ArrayList<>();
 		orders.add(qStore.isAdvertised.desc());
 
-		switch (sortType) {
-			case "dib" -> {
+		switch (sortType.name()) {
+			case "DIB" -> {
 				orders.add(qStore.dibCount.desc());
 			}
-			case "rating" -> {
+			case "RATING" -> {
 				orders.add(qStore.rating.desc());
 			}
 
@@ -108,8 +108,12 @@ public class StoreQueryRepositoryImpl implements StoreQueryRepository {
 	private List<OrderSpecifier<?>> getOrderCountSortOrders() {
 		QOrder qOrder = QOrder.order;
 
-		OrderSpecifier<Long> orderCountDesc =
-			Expressions.numberTemplate(Long.class, "count({0})", qOrder.id).desc();
+		OrderSpecifier<Long> orderCountDesc = Expressions.numberTemplate(
+			Long.class,
+			"count(case when {0} = {1} then 1 end)",
+			qOrder.status,
+			OrderStatus.FINISHED
+		).desc();
 
 		return List.of(qStore.isAdvertised.desc(), orderCountDesc, qStore.id.desc());
 	}

--- a/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepositoryImpl.java
+++ b/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.example.dishpatch.infra.db.store.repository;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.data.domain.PageRequest;
@@ -8,9 +9,13 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 import com.example.dishpatch.api.store.response.StoreResponse;
+import com.example.dishpatch.infra.db.order.entity.OrderStatus;
+import com.example.dishpatch.infra.db.order.entity.QOrder;
 import com.example.dishpatch.infra.db.store.entity.QStore;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -23,26 +28,56 @@ public class StoreQueryRepositoryImpl implements StoreQueryRepository {
 	private final QStore qStore = QStore.store;
 
 	@Override
-	public Slice<StoreResponse> findAllByCategoryId(Long categoryId, Long cursorId, int size) {
-		List<StoreResponse> stores = queryFactory
-			.select(Projections.constructor(StoreResponse.class,
-				qStore.id,
-				qStore.name,
-				qStore.image,
-				qStore.deliveryFee,
-				qStore.minDeliveryPrice,
-				qStore.rating,
-				qStore.reviewCount
-			))
-			.from(qStore)
-			.where(
-				categoryEq(categoryId),
-				qStore.deletedDate.isNull(),
-				ltCursorId(cursorId)
-			)
-			.orderBy(qStore.isAdvertised.desc(), qStore.id.desc())
-			.limit(size + 1)
-			.fetch();
+	public Slice<StoreResponse> findAllByCategoryId(String sortType, Long categoryId, Long cursorId, int size) {
+		List<StoreResponse> stores;
+
+		if ("orderCount".equals(sortType)) {
+			QOrder qOrder = QOrder.order;
+
+			stores = queryFactory
+				.select(Projections.constructor(StoreResponse.class,
+					qStore.id,
+					qStore.name,
+					qStore.image,
+					qStore.deliveryFee,
+					qStore.minDeliveryPrice,
+					qStore.rating,
+					qStore.reviewCount
+				))
+				.from(qStore)
+				.leftJoin(qOrder).on(qOrder.store.id.eq(qStore.id))
+				.where(
+					categoryEq(categoryId),
+					qStore.deletedDate.isNull(),
+					ltCursorId(cursorId),
+					qOrder.status.eq(OrderStatus.FINISHED)
+				)
+				.groupBy(qStore.id)
+				.orderBy(getOrderCountSortOrders().toArray(OrderSpecifier[]::new))
+				.limit(size + 1)
+				.fetch();
+
+		} else {
+			stores = queryFactory
+				.select(Projections.constructor(StoreResponse.class,
+					qStore.id,
+					qStore.name,
+					qStore.image,
+					qStore.deliveryFee,
+					qStore.minDeliveryPrice,
+					qStore.rating,
+					qStore.reviewCount
+				))
+				.from(qStore)
+				.where(
+					categoryEq(categoryId),
+					qStore.deletedDate.isNull(),
+					ltCursorId(cursorId)
+				)
+				.orderBy(getSortOrders(sortType).toArray(OrderSpecifier[]::new))
+				.limit(size + 1)
+				.fetch();
+		}
 
 		boolean hasNext = stores.size() > size;
 
@@ -51,6 +86,32 @@ public class StoreQueryRepositoryImpl implements StoreQueryRepository {
 		}
 
 		return new SliceImpl<>(stores, PageRequest.of(0, size), hasNext);
+	}
+
+	private List<OrderSpecifier<?>> getSortOrders(String sortType) {
+		List<OrderSpecifier<?>> orders = new ArrayList<>();
+		orders.add(qStore.isAdvertised.desc());
+
+		switch (sortType) {
+			case "dib" -> {
+				orders.add(qStore.dibCount.desc());
+			}
+			case "rating" -> {
+				orders.add(qStore.rating.desc());
+			}
+
+		}
+		orders.add(qStore.id.desc());
+		return orders;
+	}
+
+	private List<OrderSpecifier<?>> getOrderCountSortOrders() {
+		QOrder qOrder = QOrder.order;
+
+		OrderSpecifier<Long> orderCountDesc =
+			Expressions.numberTemplate(Long.class, "count({0})", qOrder.id).desc();
+
+		return List.of(qStore.isAdvertised.desc(), orderCountDesc, qStore.id.desc());
 	}
 
 	private BooleanExpression categoryEq(Long categoryId) {

--- a/src/test/java/com/example/dishpatch/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/example/dishpatch/domain/store/service/StoreServiceTest.java
@@ -203,7 +203,7 @@ class StoreServiceTest {
 
 		Dib dib = Dib.of(user, store);
 
-		when(storeRepository.existsByIdAndDeletedDateIsNull(storeId)).thenReturn(true);
+		when(storeRepository.findByIdAndDeletedDateIsNull(storeId)).thenReturn(Optional.of(store));
 		when(dibRepository.findByUserIdAndStoreId(userId, storeId)).thenReturn(Optional.of(dib));
 
 		ArgumentCaptor<Dib> dibCaptor = ArgumentCaptor.forClass(Dib.class);
@@ -225,7 +225,7 @@ class StoreServiceTest {
 
 		UserAuth userAuth = mock(UserAuth.class);
 
-		when(storeRepository.existsByIdAndDeletedDateIsNull(storeId)).thenReturn(false);
+		when(storeRepository.findByIdAndDeletedDateIsNull(storeId)).thenReturn(Optional.empty());
 
 		// when & then
 		BizException exception = assertThrows(BizException.class,
@@ -243,7 +243,8 @@ class StoreServiceTest {
 		UserAuth userAuth = mock(UserAuth.class);
 		when(userAuth.getId()).thenReturn(userId);
 
-		when(storeRepository.existsByIdAndDeletedDateIsNull(storeId)).thenReturn(true);
+		Store store = Store.builder().build();
+		when(storeRepository.findByIdAndDeletedDateIsNull(storeId)).thenReturn(Optional.of(store));
 		when(dibRepository.findByUserIdAndStoreId(userId, storeId)).thenReturn(Optional.empty());
 
 		// when & then


### PR DESCRIPTION
## 작업내용
추천 가게 조회 api
추천 가게 정렬 기준 -> 찜수, 평점, 주문 완료한 주문수
모든 조회 결과는 광고 먼저보여줌

## 변경사항
추천 가게 조회 api와 카테고리별 가게 조회 api를 하나로 합침
가게 찜했을 때랑 찜해제했을 때 store 엔티티의 dibCount을 각각 +1, -1 해줌

## 팀원에게 전할 말

## 체크 리스트
- [ ] 테스트 코드 작성
- [x] 포스트맨 확인
