### PR TITLE
feat: 가게 검색 api

### DIFF
--- a/src/main/java/com/example/dishpatch/api/store/controller/StoreController.java
+++ b/src/main/java/com/example/dishpatch/api/store/controller/StoreController.java
@@ -81,11 +81,7 @@ public class StoreController {
 		@RequestParam(required = false) Long cursorId,
 		@RequestParam(defaultValue = "10") int size
 	) {
-		long start = System.currentTimeMillis();
-		SliceResponse<StoreResponse> store = storeService.getStore(categoryId, cursorId, size);
-		long end = System.currentTimeMillis();
-		System.out.println("걸린 시간 :" + (end - start));
-		return ResponseEntity.ok(store);
+		return ResponseEntity.ok(storeService.getStore(categoryId, cursorId, size));
 	}
 
 	@GetMapping("/recommend")

--- a/src/main/java/com/example/dishpatch/api/store/controller/StoreController.java
+++ b/src/main/java/com/example/dishpatch/api/store/controller/StoreController.java
@@ -77,12 +77,24 @@ public class StoreController {
 
 	@GetMapping
 	public ResponseEntity<SliceResponse<StoreResponse>> getStore(
-		@RequestParam(required = false) SortType sortType,  // dib, rating, orderCount
 		@RequestParam(required = false) Long categoryId,
 		@RequestParam(required = false) Long cursorId,
 		@RequestParam(defaultValue = "10") int size
 	) {
-		return ResponseEntity.ok(storeService.getStore(sortType, categoryId, cursorId, size));
+		long start = System.currentTimeMillis();
+		SliceResponse<StoreResponse> store = storeService.getStore(categoryId, cursorId, size);
+		long end = System.currentTimeMillis();
+		System.out.println("걸린 시간 :" + (end - start));
+		return ResponseEntity.ok(store);
+	}
+
+	@GetMapping("/recommend")
+	public ResponseEntity<SliceResponse<StoreResponse>> getRecommendStore(
+		@RequestParam SortType sortType,  // DIB, RATING, ORDER_COUNT
+		@RequestParam(required = false) Long cursorId,
+		@RequestParam(defaultValue = "10") int size
+	) {
+		return ResponseEntity.ok(storeService.getRecommendStore(sortType, cursorId, size));
 	}
 
 	@GetMapping("/{storeId}")

--- a/src/main/java/com/example/dishpatch/api/store/controller/StoreController.java
+++ b/src/main/java/com/example/dishpatch/api/store/controller/StoreController.java
@@ -18,6 +18,7 @@ import com.example.dishpatch.api.store.request.StoreUpdateRequest;
 import com.example.dishpatch.api.store.response.StoreCreateResponse;
 import com.example.dishpatch.api.store.response.StoreInfoResponse;
 import com.example.dishpatch.api.store.response.StoreResponse;
+import com.example.dishpatch.api.store.response.StoreSearchResponse;
 import com.example.dishpatch.domain.store.service.StoreService;
 import com.example.dishpatch.global.response.pagination.SliceResponse;
 import com.example.dishpatch.global.security.UserAuth;
@@ -88,6 +89,15 @@ public class StoreController {
 		@PathVariable("storeId") Long storeId
 	) {
 		return ResponseEntity.ok(storeService.getStoreInfo(storeId));
+	}
+
+	@GetMapping("/search")
+	public ResponseEntity<SliceResponse<StoreSearchResponse>> searchStore(
+		@RequestParam String keyword,
+		@RequestParam(required = false) Long cursorId,
+		@RequestParam(defaultValue = "10") int size
+	) {
+		return ResponseEntity.ok(storeService.searchStore(keyword, cursorId, size));
 	}
 
 }

--- a/src/main/java/com/example/dishpatch/api/store/controller/StoreController.java
+++ b/src/main/java/com/example/dishpatch/api/store/controller/StoreController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.dishpatch.api.store.request.StoreCreateRequest;
 import com.example.dishpatch.api.store.request.StoreUpdateRequest;
+import com.example.dishpatch.api.store.response.PopularKeywordsResponse;
 import com.example.dishpatch.api.store.response.StoreCreateResponse;
 import com.example.dishpatch.api.store.response.StoreInfoResponse;
 import com.example.dishpatch.api.store.response.StoreResponse;
@@ -98,6 +99,11 @@ public class StoreController {
 		@RequestParam(defaultValue = "10") int size
 	) {
 		return ResponseEntity.ok(storeService.searchStore(keyword, cursorId, size));
+	}
+
+	@GetMapping("/search/popular")
+	public ResponseEntity<PopularKeywordsResponse> searchPopularKeyword() {
+		return ResponseEntity.ok(storeService.searchPopularKeyword());
 	}
 
 }

--- a/src/main/java/com/example/dishpatch/api/store/response/KeywordRank.java
+++ b/src/main/java/com/example/dishpatch/api/store/response/KeywordRank.java
@@ -1,0 +1,8 @@
+package com.example.dishpatch.api.store.response;
+
+public record KeywordRank(
+	int rank,
+	String keyword,
+	int count
+) {
+}

--- a/src/main/java/com/example/dishpatch/api/store/response/PopularKeywordsResponse.java
+++ b/src/main/java/com/example/dishpatch/api/store/response/PopularKeywordsResponse.java
@@ -1,0 +1,11 @@
+package com.example.dishpatch.api.store.response;
+
+import java.util.List;
+
+public record PopularKeywordsResponse(
+	List<KeywordRank> keywordRanks
+) {
+	public static PopularKeywordsResponse of(List<KeywordRank> keywordRanks) {
+		return new PopularKeywordsResponse(keywordRanks);
+	}
+}

--- a/src/main/java/com/example/dishpatch/api/store/response/StoreResponse.java
+++ b/src/main/java/com/example/dishpatch/api/store/response/StoreResponse.java
@@ -30,7 +30,7 @@ public class StoreResponse implements CursorSupport {
 	}
 
 	@Override
-	public Long getCursorId() {
+	public Long getId() {
 		return id;
 	}
 

--- a/src/main/java/com/example/dishpatch/api/store/response/StoreResponse.java
+++ b/src/main/java/com/example/dishpatch/api/store/response/StoreResponse.java
@@ -1,5 +1,7 @@
 package com.example.dishpatch.api.store.response;
 
+import java.io.Serializable;
+
 import com.example.dishpatch.global.response.pagination.CursorSupport;
 import com.example.dishpatch.infra.db.store.entity.Store;
 
@@ -8,7 +10,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class StoreResponse implements CursorSupport {
+public class StoreResponse implements CursorSupport, Serializable {
 	Long id;
 	String name;
 	String imageUrl;

--- a/src/main/java/com/example/dishpatch/api/store/response/StoreSearchResponse.java
+++ b/src/main/java/com/example/dishpatch/api/store/response/StoreSearchResponse.java
@@ -1,0 +1,39 @@
+package com.example.dishpatch.api.store.response;
+
+import java.util.List;
+
+import com.example.dishpatch.global.response.pagination.CursorSupport;
+
+import lombok.Getter;
+
+@Getter
+public class StoreSearchResponse implements CursorSupport {
+	Long id;
+	String name;
+	String imageUrl;
+	int deliveryFee;
+	int minDeliveryPrice;
+	double rating;
+	int reviewCount;
+	List<String> menuNameList;
+
+	public StoreSearchResponse(Long id, String name, String imageUrl, int deliveryFee, int minDeliveryPrice,
+		double rating, int reviewCount) {
+		this.id = id;
+		this.name = name;
+		this.imageUrl = imageUrl;
+		this.deliveryFee = deliveryFee;
+		this.minDeliveryPrice = minDeliveryPrice;
+		this.rating = rating;
+		this.reviewCount = reviewCount;
+	}
+
+	@Override
+	public Long getId() {
+		return id;
+	}
+
+	public void setMenuNameList(List<String> menuNameList) {
+		this.menuNameList = (menuNameList != null) ? menuNameList : List.of();
+	}
+}

--- a/src/main/java/com/example/dishpatch/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/dishpatch/domain/store/service/StoreService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.dishpatch.api.store.request.StoreCreateRequest;
 import com.example.dishpatch.api.store.request.StoreUpdateRequest;
+import com.example.dishpatch.api.store.response.PopularKeywordsResponse;
 import com.example.dishpatch.api.store.response.StoreCreateResponse;
 import com.example.dishpatch.api.store.response.StoreInfoResponse;
 import com.example.dishpatch.api.store.response.StoreResponse;
@@ -29,6 +30,7 @@ import com.example.dishpatch.infra.db.store.entity.Store;
 import com.example.dishpatch.infra.db.store.enums.SortType;
 import com.example.dishpatch.infra.db.store.repository.CategoryRepository;
 import com.example.dishpatch.infra.db.store.repository.DibRepository;
+import com.example.dishpatch.infra.db.store.repository.KeywordRedisRepository;
 import com.example.dishpatch.infra.db.store.repository.StoreRepository;
 import com.example.dishpatch.infra.db.user.entity.User;
 import com.example.dishpatch.infra.db.user.repository.UserRepository;
@@ -38,6 +40,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Service
 public class StoreService {
+	private final KeywordRedisRepository keywordRedisRepository;
 	private final StoreRepository storeRepository;
 	private final CategoryRepository categoryRepository;
 	private final DibRepository dibRepository;
@@ -153,7 +156,11 @@ public class StoreService {
 	}
 
 	public SliceResponse<StoreSearchResponse> searchStore(String keyword, Long cursorId, int size) {
+		keywordRedisRepository.increaseKeywordScore(keyword);
 		return SliceResponse.from(storeRepository.findAllByKeyword(keyword, cursorId, size));
 	}
 
+	public PopularKeywordsResponse searchPopularKeyword() {
+		return PopularKeywordsResponse.of(keywordRedisRepository.getPopularKeywords(10));
+	}
 }

--- a/src/main/java/com/example/dishpatch/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/dishpatch/domain/store/service/StoreService.java
@@ -14,6 +14,7 @@ import com.example.dishpatch.api.store.request.StoreUpdateRequest;
 import com.example.dishpatch.api.store.response.StoreCreateResponse;
 import com.example.dishpatch.api.store.response.StoreInfoResponse;
 import com.example.dishpatch.api.store.response.StoreResponse;
+import com.example.dishpatch.api.store.response.StoreSearchResponse;
 import com.example.dishpatch.global.exception.BizException;
 import com.example.dishpatch.global.response.pagination.SliceResponse;
 import com.example.dishpatch.global.security.UserAuth;
@@ -150,4 +151,9 @@ public class StoreService {
 
 		return StoreInfoResponse.from(store);
 	}
+
+	public SliceResponse<StoreSearchResponse> searchStore(String keyword, Long cursorId, int size) {
+		return SliceResponse.from(storeRepository.findAllByKeyword(keyword, cursorId, size));
+	}
+
 }

--- a/src/main/java/com/example/dishpatch/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/dishpatch/domain/store/service/StoreService.java
@@ -127,10 +127,10 @@ public class StoreService {
 
 		store.softDelete();
 
-		reviewRepository.deleteAllByStoreId(storeId);
-		ceoReviewRepository.deleteAllByStoreId(storeId);
+		reviewRepository.bulkSoftDeleteByStoreId(storeId);
+		ceoReviewRepository.bulkSoftDeleteByStoreId(storeId);
 
-		menuRepository.bulkSoftDeleteByStoreId(storeId, LocalDateTime.now());
+		menuRepository.bulkSoftDeleteByStoreId(storeId);
 		menuOptionRepository.bulkSoftDeleteByStoreId(storeId, LocalDateTime.now());
 
 		dibRepository.deleteAllByStoreId(storeId);

--- a/src/main/java/com/example/dishpatch/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/dishpatch/domain/store/service/StoreService.java
@@ -6,6 +6,8 @@ import static com.example.dishpatch.domain.user.exception.UserErrorCode.*;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,6 +54,7 @@ public class StoreService {
 	private final CartRepository cartRepository;
 
 	@Transactional
+	@CacheEvict(value = "store", allEntries = true)
 	public StoreCreateResponse createStore(UserAuth userAuth, StoreCreateRequest request) {
 		User user = userRepository.findByIdAndDeletedDateIsNull(userAuth.getId())
 			.orElseThrow(() -> new BizException(INVALID_ID));
@@ -72,6 +75,7 @@ public class StoreService {
 	}
 
 	@Transactional
+	@CacheEvict(value = "store", allEntries = true)
 	public void updateStore(UserAuth userAuth, Long storeId, StoreUpdateRequest request) {
 		Category category = categoryRepository.findById(request.categoryId())
 			.orElseThrow(() -> new BizException(CATEGORY_NOT_FOUND));
@@ -117,6 +121,7 @@ public class StoreService {
 	}
 
 	@Transactional
+	@CacheEvict(value = "store", allEntries = true)
 	public void deleteStore(UserAuth userAuth, Long storeId) {
 		Store store = storeRepository.findByIdAndDeletedDateIsNull(storeId)
 			.orElseThrow(() -> new BizException(STORE_NOT_FOUND));
@@ -138,13 +143,20 @@ public class StoreService {
 	}
 
 	@Transactional(readOnly = true)
-	public SliceResponse<StoreResponse> getStore(SortType sortType, Long categoryId, Long cursorId, int size) {
+	@Cacheable(value = "store",
+		key = "(#categoryId != null ? #categoryId : 'ALLCATEGORY') + ':' + #size",
+		condition = "#cursorId == null")
+	public SliceResponse<StoreResponse> getStore(Long categoryId, Long cursorId, int size) {
 		if (categoryId != null) {
 			categoryRepository.findById(categoryId)
 				.orElseThrow(() -> new BizException(CATEGORY_NOT_FOUND));
 		}
 
-		return SliceResponse.from(storeRepository.findAllByCategoryId(sortType, categoryId, cursorId, size));
+		return SliceResponse.from(storeRepository.findAllByCategoryId(categoryId, cursorId, size));
+	}
+
+	public SliceResponse<StoreResponse> getRecommendStore(SortType sortType, Long cursorId, int size) {
+		return SliceResponse.from(storeRepository.findAllBySortType(sortType, cursorId, size));
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/example/dishpatch/global/config/CacheConfig.java
+++ b/src/main/java/com/example/dishpatch/global/config/CacheConfig.java
@@ -1,0 +1,9 @@
+package com.example.dishpatch.global.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+}

--- a/src/main/java/com/example/dishpatch/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/dishpatch/global/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
 				-> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/users/signup", "/users/login", "/stores", "/stores/{storeId}", "/stores/search",
-					"/stores/search/popular")
+					"/stores/search/popular", "/stores/recommend")
 				.permitAll()
 				.requestMatchers("/admin/**")
 				.hasRole("ADMIN")

--- a/src/main/java/com/example/dishpatch/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/dishpatch/global/config/SecurityConfig.java
@@ -34,7 +34,8 @@ public class SecurityConfig {
 			.sessionManagement(session
 				-> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/users/signup", "/users/login", "/stores", "/stores/{storeId}", "/stores/search")
+				.requestMatchers("/users/signup", "/users/login", "/stores", "/stores/{storeId}", "/stores/search",
+					"/stores/search/popular")
 				.permitAll()
 				.requestMatchers("/admin/**")
 				.hasRole("ADMIN")

--- a/src/main/java/com/example/dishpatch/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/dishpatch/global/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
 			.sessionManagement(session
 				-> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/users/signup", "/users/login", "/stores", "/stores/{storeId}")
+				.requestMatchers("/users/signup", "/users/login", "/stores", "/stores/{storeId}", "/stores/search")
 				.permitAll()
 				.requestMatchers("/admin/**")
 				.hasRole("ADMIN")

--- a/src/main/java/com/example/dishpatch/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/dishpatch/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.example.dishpatch.global.exception;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -22,6 +23,14 @@ public class GlobalExceptionHandler {
 		return ResponseEntity
 			.badRequest()
 			.body(ErrorResponse.of(CommonErrorCode.INVALID_INPUT_VALUE, exception.getBindingResult()));
+	}
+
+	@ExceptionHandler(MissingServletRequestParameterException.class)
+	public ResponseEntity<String> handleMissingServletRequestParameter(
+		MissingServletRequestParameterException exception) {
+		String missingParam = exception.getParameterName();
+		String message = String.format("필수 파라미터 '%s'가 없습니다.", missingParam);
+		return ResponseEntity.badRequest().body(message);
 	}
 
 }

--- a/src/main/java/com/example/dishpatch/global/response/pagination/CursorSupport.java
+++ b/src/main/java/com/example/dishpatch/global/response/pagination/CursorSupport.java
@@ -1,5 +1,5 @@
 package com.example.dishpatch.global.response.pagination;
 
 public interface CursorSupport {
-	Long getCursorId();
+	Long getId();
 }

--- a/src/main/java/com/example/dishpatch/global/response/pagination/SliceResponse.java
+++ b/src/main/java/com/example/dishpatch/global/response/pagination/SliceResponse.java
@@ -1,17 +1,23 @@
 package com.example.dishpatch.global.response.pagination;
 
+import java.io.Serializable;
 import java.util.List;
 
 import org.springframework.data.domain.Slice;
 
-public record SliceResponse<T>(
-	List<T> content,
-	boolean hasNext,
-	Long nextCursorId,
-	int size,
-	int contentSize,
-	boolean empty
-) {
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SliceResponse<T> implements Serializable {
+	List<T> content;
+	boolean hasNext;
+	Long nextCursorId;
+	int size;
+	int contentSize;
+	boolean empty;
+
 	public static <T extends CursorSupport> SliceResponse<T> from(Slice<T> slice) {
 		List<T> content = slice.getContent();
 		Long nextCursorId = content.isEmpty() ? null : content.get(content.size() - 1).getId();

--- a/src/main/java/com/example/dishpatch/global/response/pagination/SliceResponse.java
+++ b/src/main/java/com/example/dishpatch/global/response/pagination/SliceResponse.java
@@ -14,7 +14,7 @@ public record SliceResponse<T>(
 ) {
 	public static <T extends CursorSupport> SliceResponse<T> from(Slice<T> slice) {
 		List<T> content = slice.getContent();
-		Long nextCursorId = content.isEmpty() ? null : content.get(content.size() - 1).getCursorId();
+		Long nextCursorId = content.isEmpty() ? null : content.get(content.size() - 1).getId();
 
 		return new SliceResponse<>(
 			content,

--- a/src/main/java/com/example/dishpatch/infra/db/menu/repository/MenuRepository.java
+++ b/src/main/java/com/example/dishpatch/infra/db/menu/repository/MenuRepository.java
@@ -1,7 +1,5 @@
 package com.example.dishpatch.infra.db.menu.repository;
 
-import java.time.LocalDateTime;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -13,15 +11,15 @@ import io.lettuce.core.dynamic.annotation.Param;
 public interface MenuRepository extends JpaRepository<Menu, Long>, MenuQueryRepository {
 
 	@Modifying(clearAutomatically = true)
-	@Query("UPDATE Menu m SET m.deletedDate = :now WHERE m.store.id = :storeId AND m.deletedDate IS NULL")
-	void bulkSoftDeleteByStoreId(Long storeId, LocalDateTime now);
+	@Query("UPDATE Menu m SET m.deletedDate = CURRENT_TIMESTAMP WHERE m.store.id = :storeId")
+	void bulkSoftDeleteByStoreId(Long storeId);
 
 	@Modifying(clearAutomatically = true, flushAutomatically = true)
 	@Query(value = """
-		UPDATE menu m
-      	JOIN store s ON m.store_id = s.id
-        SET m.deleted_date = CURRENT_TIMESTAMP
-        WHERE s.user_id = :userId
-""", nativeQuery = true)
+				UPDATE menu m
+		      	JOIN store s ON m.store_id = s.id
+		        SET m.deleted_date = CURRENT_TIMESTAMP
+		        WHERE s.user_id = :userId
+		""", nativeQuery = true)
 	void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/dishpatch/infra/db/review/repository/CeoReviewRepository.java
+++ b/src/main/java/com/example/dishpatch/infra/db/review/repository/CeoReviewRepository.java
@@ -9,12 +9,12 @@ import com.example.dishpatch.infra.db.review.entity.CeoReview;
 public interface CeoReviewRepository extends JpaRepository<CeoReview, Long> {
 	@Modifying(clearAutomatically = true)
 	@Query("""
-		    DELETE FROM CeoReview cr
+		    UPDATE CeoReview cr SET cr.deletedDate = CURRENT_TIMESTAMP
 		    WHERE cr.review.id IN (
 		        SELECT cr.id FROM Review r WHERE r.store.id = :storeId AND r.deletedDate IS NOT NULL
 		    )
 		""")
-	int deleteAllByStoreId(Long storeId);
+	int bulkSoftDeleteByStoreId(Long storeId);
 
 	@Modifying(clearAutomatically = true)
 	@Query("UPDATE CeoReview c SET c.deletedDate = CURRENT_TIMESTAMP WHERE c.user.id = :userId AND c.deletedDate IS NULL")

--- a/src/main/java/com/example/dishpatch/infra/db/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/dishpatch/infra/db/review/repository/ReviewRepository.java
@@ -28,7 +28,10 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 		Pageable pageable);
 
 	@Modifying(clearAutomatically = true)
-	void deleteAllByStoreId(Long storeId);
+	@Query("""
+		    UPDATE Review r SET r.deletedDate = CURRENT_TIMESTAMP WHERE r.store.id = :storeId
+		""")
+	void bulkSoftDeleteByStoreId(Long storeId);
 
 	@Modifying(clearAutomatically = true)
 	@Query(value = """

--- a/src/main/java/com/example/dishpatch/infra/db/store/repository/KeywordRedisRepository.java
+++ b/src/main/java/com/example/dishpatch/infra/db/store/repository/KeywordRedisRepository.java
@@ -1,0 +1,78 @@
+package com.example.dishpatch.infra.db.store.repository;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.dishpatch.api.store.response.KeywordRank;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class KeywordRedisRepository {
+	private final StringRedisTemplate redisTemplate;
+	private static final String POPULAR_KEYWORDS_KEY = "popular:keywords:"; // Redis에 저장할 키
+	private static final Duration TTL = Duration.ofHours(2); // 2시간 뒤 만료
+
+	public void increaseKeywordScore(String keyword) {
+		if (keyword == null || keyword.isBlank()) {
+			return;
+		}
+		keyword = keyword.replace(" ", "");
+
+		String key = generateCurrentHourKey();
+
+		redisTemplate.opsForZSet().incrementScore(key, keyword, 1);
+		redisTemplate.expire(POPULAR_KEYWORDS_KEY, TTL);
+	}
+
+	@Transactional(readOnly = true)
+	public List<KeywordRank> getPopularKeywords(int size) {
+		List<KeywordRank> keywordRanks = new ArrayList<>();
+		String key = generatePreviousHourKey();
+
+		Set<ZSetOperations.TypedTuple<String>> typedTuples = redisTemplate.opsForZSet()
+			.reverseRangeWithScores(key, 0, size - 1);
+
+		if (typedTuples == null || typedTuples.isEmpty()) {
+			key = generateCurrentHourKey();
+			typedTuples = redisTemplate.opsForZSet()
+				.reverseRangeWithScores(key, 0, size - 1);
+		}
+
+		int rank = 1;
+		for (ZSetOperations.TypedTuple<String> tuple : typedTuples) {
+			if (tuple.getValue() == null || tuple.getScore() == null) {
+				continue;
+			}
+			keywordRanks.add(new KeywordRank(
+				rank++,
+				tuple.getValue(),
+				tuple.getScore().intValue()
+			));
+		}
+
+		return keywordRanks;
+	}
+
+	private String generateCurrentHourKey() {
+		LocalDateTime now = LocalDateTime.now();
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHH");
+		return POPULAR_KEYWORDS_KEY + now.format(formatter);
+	}
+
+	private String generatePreviousHourKey() {
+		LocalDateTime now = LocalDateTime.now().minusHours(1);
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHH");
+		return POPULAR_KEYWORDS_KEY + now.format(formatter);
+	}
+}

--- a/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepository.java
+++ b/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepository.java
@@ -7,7 +7,9 @@ import com.example.dishpatch.api.store.response.StoreSearchResponse;
 import com.example.dishpatch.infra.db.store.enums.SortType;
 
 public interface StoreQueryRepository {
-	Slice<StoreResponse> findAllByCategoryId(SortType sortType, Long categoryId, Long cursorId, int size);
+	Slice<StoreResponse> findAllBySortType(SortType sortType, Long cursorId, int size);
 
 	Slice<StoreSearchResponse> findAllByKeyword(String keyword, Long cursorId, int size);
+
+	Slice<StoreResponse> findAllByCategoryId(Long categoryId, Long cursorId, int size);
 }

--- a/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepository.java
+++ b/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepository.java
@@ -3,8 +3,11 @@ package com.example.dishpatch.infra.db.store.repository;
 import org.springframework.data.domain.Slice;
 
 import com.example.dishpatch.api.store.response.StoreResponse;
+import com.example.dishpatch.api.store.response.StoreSearchResponse;
 import com.example.dishpatch.infra.db.store.enums.SortType;
 
 public interface StoreQueryRepository {
 	Slice<StoreResponse> findAllByCategoryId(SortType sortType, Long categoryId, Long cursorId, int size);
+
+	Slice<StoreSearchResponse> findAllByKeyword(String keyword, Long cursorId, int size);
 }

--- a/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepositoryImpl.java
+++ b/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepositoryImpl.java
@@ -1,7 +1,10 @@
 package com.example.dishpatch.infra.db.store.repository;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -9,13 +12,17 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 import com.example.dishpatch.api.store.response.StoreResponse;
+import com.example.dishpatch.api.store.response.StoreSearchResponse;
+import com.example.dishpatch.infra.db.menu.entity.QMenu;
 import com.example.dishpatch.infra.db.order.entity.OrderStatus;
 import com.example.dishpatch.infra.db.order.entity.QOrder;
 import com.example.dishpatch.infra.db.store.entity.QStore;
 import com.example.dishpatch.infra.db.store.enums.SortType;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -27,14 +34,14 @@ public class StoreQueryRepositoryImpl implements StoreQueryRepository {
 
 	private final JPAQueryFactory queryFactory;
 	private final QStore qStore = QStore.store;
+	private final QOrder qOrder = QOrder.order;
+	private final QMenu qMenu = QMenu.menu;
 
 	@Override
 	public Slice<StoreResponse> findAllByCategoryId(SortType sortType, Long categoryId, Long cursorId, int size) {
 		List<StoreResponse> stores;
 
 		if ("ORDER_COUNT".equals(sortType.name())) {
-			QOrder qOrder = QOrder.order;
-
 			stores = queryFactory
 				.select(Projections.constructor(StoreResponse.class,
 					qStore.id,
@@ -88,6 +95,75 @@ public class StoreQueryRepositoryImpl implements StoreQueryRepository {
 		return new SliceImpl<>(stores, PageRequest.of(0, size), hasNext);
 	}
 
+	@Override
+	public Slice<StoreSearchResponse> findAllByKeyword(String keyword, Long cursorId, int size) {
+		List<StoreSearchResponse> stores = queryFactory
+			.select(Projections.constructor(StoreSearchResponse.class,
+				qStore.id,
+				qStore.name,
+				qStore.image,
+				qStore.deliveryFee,
+				qStore.minDeliveryPrice,
+				qStore.rating,
+				qStore.reviewCount
+			))
+			.from(qStore)
+			.leftJoin(qMenu).on(qMenu.store.id.eq(qStore.id))
+			.where(
+				qStore.deletedDate.isNull(),
+				qStore.name.contains(keyword).or(qMenu.name.contains(keyword)),
+				ltCursorId(cursorId)
+			)
+			.groupBy(qStore.id)
+			.orderBy(qStore.isAdvertised.desc(), qStore.id.desc())
+			.limit(size + 1)
+			.fetch();
+
+		boolean hasNext = stores.size() > size;
+
+		if (hasNext) {
+			stores = stores.subList(0, size); // 1개 더 가져온 것 잘라냄
+		}
+
+		if (stores.isEmpty()) {
+			return new SliceImpl<>(Collections.emptyList(), PageRequest.of(0, size), hasNext);
+		}
+
+		List<Long> storeIds = stores.stream()
+			.map(StoreSearchResponse::getId)
+			.toList();
+
+		List<Tuple> menuTuples = queryFactory
+			.select(qMenu.store.id, qMenu.name)
+			.from(qMenu)
+			.where(
+				qMenu.store.id.in(storeIds),
+				qMenu.deletedDate.isNull()
+			)
+			.orderBy(
+				new CaseBuilder()
+					.when(qMenu.name.eq(keyword)).then(2)
+					.when(qMenu.name.contains(keyword)).then(1)
+					.otherwise(0)
+					.desc(),
+				qMenu.name.asc()
+			)
+			.fetch();
+
+		Map<Long, List<String>> storeIdToMenuNames = menuTuples.stream()
+			.collect(Collectors.groupingBy(
+				tuple -> tuple.get(qMenu.store.id),
+				Collectors.mapping(tuple -> tuple.get(qMenu.name), Collectors.toList())
+			));
+
+		for (StoreSearchResponse store : stores) {
+			List<String> menuNames = storeIdToMenuNames.getOrDefault(store.getId(), List.of());
+			store.setMenuNameList(menuNames);
+		}
+
+		return new SliceImpl<>(stores, PageRequest.of(0, size), hasNext);
+	}
+
 	private List<OrderSpecifier<?>> getSortOrders(SortType sortType) {
 		List<OrderSpecifier<?>> orders = new ArrayList<>();
 		orders.add(qStore.isAdvertised.desc());
@@ -106,8 +182,6 @@ public class StoreQueryRepositoryImpl implements StoreQueryRepository {
 	}
 
 	private List<OrderSpecifier<?>> getOrderCountSortOrders() {
-		QOrder qOrder = QOrder.order;
-
 		OrderSpecifier<Long> orderCountDesc = Expressions.numberTemplate(
 			Long.class,
 			"count(case when {0} = {1} then 1 end)",

--- a/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepositoryImpl.java
+++ b/src/main/java/com/example/dishpatch/infra/db/store/repository/StoreQueryRepositoryImpl.java
@@ -38,10 +38,10 @@ public class StoreQueryRepositoryImpl implements StoreQueryRepository {
 	private final QMenu qMenu = QMenu.menu;
 
 	@Override
-	public Slice<StoreResponse> findAllByCategoryId(SortType sortType, Long categoryId, Long cursorId, int size) {
+	public Slice<StoreResponse> findAllBySortType(SortType sortType, Long cursorId, int size) {
 		List<StoreResponse> stores;
 
-		if ("ORDER_COUNT".equals(sortType.name())) {
+		if (sortType != null && "ORDER_COUNT".equals(sortType.name())) {
 			stores = queryFactory
 				.select(Projections.constructor(StoreResponse.class,
 					qStore.id,
@@ -55,7 +55,6 @@ public class StoreQueryRepositoryImpl implements StoreQueryRepository {
 				.from(qStore)
 				.leftJoin(qOrder).on(qOrder.store.id.eq(qStore.id))
 				.where(
-					categoryEq(categoryId),
 					qStore.deletedDate.isNull(),
 					ltCursorId(cursorId)
 				)
@@ -77,7 +76,6 @@ public class StoreQueryRepositoryImpl implements StoreQueryRepository {
 				))
 				.from(qStore)
 				.where(
-					categoryEq(categoryId),
 					qStore.deletedDate.isNull(),
 					ltCursorId(cursorId)
 				)
@@ -164,19 +162,52 @@ public class StoreQueryRepositoryImpl implements StoreQueryRepository {
 		return new SliceImpl<>(stores, PageRequest.of(0, size), hasNext);
 	}
 
+	@Override
+	public Slice<StoreResponse> findAllByCategoryId(Long categoryId, Long cursorId, int size) {
+		List<StoreResponse> stores = queryFactory
+			.select(Projections.constructor(StoreResponse.class,
+				qStore.id,
+				qStore.name,
+				qStore.image,
+				qStore.deliveryFee,
+				qStore.minDeliveryPrice,
+				qStore.rating,
+				qStore.reviewCount
+			))
+			.from(qStore)
+			.where(
+				qStore.deletedDate.isNull(),
+				categoryEq(categoryId),
+				ltCursorId(cursorId)
+			)
+			.orderBy(qStore.isAdvertised.desc(), qStore.id.desc())
+			.limit(size + 1)
+			.fetch();
+
+		boolean hasNext = stores.size() > size;
+
+		if (hasNext) {
+			stores.remove(size);
+		}
+
+		return new SliceImpl<>(stores, PageRequest.of(0, size), hasNext);
+	}
+
 	private List<OrderSpecifier<?>> getSortOrders(SortType sortType) {
 		List<OrderSpecifier<?>> orders = new ArrayList<>();
 		orders.add(qStore.isAdvertised.desc());
 
-		switch (sortType.name()) {
-			case "DIB" -> {
-				orders.add(qStore.dibCount.desc());
+		if (sortType != null) {
+			switch (sortType.name()) {
+				case "DIB" -> {
+					orders.add(qStore.dibCount.desc());
+				}
+				case "RATING" -> {
+					orders.add(qStore.rating.desc());
+				}
 			}
-			case "RATING" -> {
-				orders.add(qStore.rating.desc());
-			}
-
 		}
+
 		orders.add(qStore.id.desc());
 		return orders;
 	}

--- a/src/test/java/com/example/dishpatch/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/example/dishpatch/domain/store/service/StoreServiceTest.java
@@ -22,6 +22,7 @@ import com.example.dishpatch.global.security.UserAuth;
 import com.example.dishpatch.infra.db.store.entity.Category;
 import com.example.dishpatch.infra.db.store.entity.Dib;
 import com.example.dishpatch.infra.db.store.entity.Store;
+import com.example.dishpatch.infra.db.store.enums.SortType;
 import com.example.dishpatch.infra.db.store.repository.CategoryRepository;
 import com.example.dishpatch.infra.db.store.repository.DibRepository;
 import com.example.dishpatch.infra.db.store.repository.StoreRepository;
@@ -42,18 +43,21 @@ class StoreServiceTest {
 	@Mock
 	private UserRepository userRepository;
 
+	private final Long userId = 1L;
+	private final Long storeId = 3L;
+	private final Long categoryId = 5L;
+	private final Long ownerId = 10L;
+	private final User user = mock(User.class);
+	private final UserAuth userAuth = mock(UserAuth.class);
+	private final Category category = mock(Category.class);
+	private final Store store = mock(Store.class);
+	private final User owner = mock(User.class);
+
 	@Test
 	void createStore_shouldSucceed() {
 		// given
-		Long userId = 1L;
-		User user = mock(User.class);
-
-		UserAuth userAuth = mock(UserAuth.class);
-		when(userAuth.getId()).thenReturn(userId);
-
-		Category category = mock(Category.class);
 		StoreCreateRequest request = mock(StoreCreateRequest.class);
-
+		when(userAuth.getId()).thenReturn(userId);
 		when(userRepository.findByIdAndDeletedDateIsNull(userId)).thenReturn(Optional.of(user));
 		when(categoryRepository.findById(any())).thenReturn(Optional.of(category));
 		when(storeRepository.countByUserIdAndDeletedDateIsNull(any())).thenReturn(2);
@@ -75,15 +79,8 @@ class StoreServiceTest {
 	@Test
 	void createMenu_whenStoreOwnLimitExceed_shouldThrowException() {
 		// given
-		Long userId = 1L;
-		User user = mock(User.class);
-
-		UserAuth userAuth = mock(UserAuth.class);
-		when(userAuth.getId()).thenReturn(userId);
-
-		Category category = mock(Category.class);
 		StoreCreateRequest request = mock(StoreCreateRequest.class);
-
+		when(userAuth.getId()).thenReturn(userId);
 		when(userRepository.findByIdAndDeletedDateIsNull(userId)).thenReturn(Optional.of(user));
 		when(categoryRepository.findById(any())).thenReturn(Optional.of(category));
 		when(storeRepository.countByUserIdAndDeletedDateIsNull(any())).thenReturn(3); // 최대 초과
@@ -98,14 +95,8 @@ class StoreServiceTest {
 	@Test
 	void createMenu_whenNotFoundCategory_shouldThrowException() {
 		// given
-		Long userId = 1L;
-		User user = mock(User.class);
-
-		UserAuth userAuth = mock(UserAuth.class);
-		when(userAuth.getId()).thenReturn(userId);
-
 		StoreCreateRequest request = mock(StoreCreateRequest.class);
-
+		when(userAuth.getId()).thenReturn(userId);
 		when(userRepository.findByIdAndDeletedDateIsNull(userId)).thenReturn(Optional.of(user));
 		when(categoryRepository.findById(any())).thenReturn(Optional.empty());
 
@@ -119,15 +110,7 @@ class StoreServiceTest {
 	@Test
 	void dibStore_shouldSucceed() {
 		// given
-		Long userId = 1L;
-		User user = mock(User.class);
-
-		Long storeId = 3L;
-		Store store = mock(Store.class);
-
-		UserAuth userAuth = mock(UserAuth.class);
 		when(userAuth.getId()).thenReturn(userId);
-
 		when(userRepository.findByIdAndDeletedDateIsNull(userId)).thenReturn(Optional.of(user));
 		when(storeRepository.findByIdAndDeletedDateIsNull(storeId)).thenReturn(Optional.of(store));
 		when(dibRepository.existsByUserIdAndStoreId(userId, storeId)).thenReturn(false);
@@ -147,14 +130,7 @@ class StoreServiceTest {
 	@Test
 	void dibStore_whenNotFoundStore_shouldThrowException() {
 		// given
-		Long userId = 1L;
-		User user = mock(User.class);
-
-		Long storeId = 3L;
-
-		UserAuth userAuth = mock(UserAuth.class);
 		when(userAuth.getId()).thenReturn(userId);
-
 		when(userRepository.findByIdAndDeletedDateIsNull(userId)).thenReturn(Optional.of(user));
 		when(storeRepository.findByIdAndDeletedDateIsNull(storeId)).thenReturn(Optional.empty());
 
@@ -168,15 +144,7 @@ class StoreServiceTest {
 	@Test
 	void dibStore_whenAlreadyDibStore_shouldThrowException() {
 		// given
-		Long userId = 1L;
-		User user = mock(User.class);
-
-		Long storeId = 3L;
-		Store store = mock(Store.class);
-
-		UserAuth userAuth = mock(UserAuth.class);
 		when(userAuth.getId()).thenReturn(userId);
-
 		when(userRepository.findByIdAndDeletedDateIsNull(userId)).thenReturn(Optional.of(user));
 		when(storeRepository.findByIdAndDeletedDateIsNull(storeId)).thenReturn(Optional.of(store));
 		when(dibRepository.existsByUserIdAndStoreId(userId, storeId)).thenReturn(true);
@@ -191,18 +159,9 @@ class StoreServiceTest {
 	@Test
 	void undibStore_shouldSucceed() {
 		// given
-		Long userId = 1L;
-		User user = mock(User.class);
-
-		Long storeId = 3L;
-		Store store = mock(Store.class);
-
-		UserAuth userAuth = mock(UserAuth.class);
 		when(userAuth.getId()).thenReturn(userId);
-
-		Dib dib = Dib.of(user, store);
-
 		when(storeRepository.findByIdAndDeletedDateIsNull(storeId)).thenReturn(Optional.of(store));
+		Dib dib = Dib.of(user, store);
 		when(dibRepository.findByUserIdAndStoreId(userId, storeId)).thenReturn(Optional.of(dib));
 
 		ArgumentCaptor<Dib> dibCaptor = ArgumentCaptor.forClass(Dib.class);
@@ -220,10 +179,6 @@ class StoreServiceTest {
 	@Test
 	void undibStore_whenNotFoundStore_shouldThrowException() {
 		// given
-		Long storeId = 3L;
-
-		UserAuth userAuth = mock(UserAuth.class);
-
 		when(storeRepository.findByIdAndDeletedDateIsNull(storeId)).thenReturn(Optional.empty());
 
 		// when & then
@@ -236,13 +191,7 @@ class StoreServiceTest {
 	@Test
 	void undibStore_whenUndibStore_shouldThrowException() {
 		// given
-		Long userId = 1L;
-		Long storeId = 3L;
-
-		UserAuth userAuth = mock(UserAuth.class);
 		when(userAuth.getId()).thenReturn(userId);
-
-		Store store = Store.builder().build();
 		when(storeRepository.findByIdAndDeletedDateIsNull(storeId)).thenReturn(Optional.of(store));
 		when(dibRepository.findByUserIdAndStoreId(userId, storeId)).thenReturn(Optional.empty());
 
@@ -256,19 +205,9 @@ class StoreServiceTest {
 	@Test
 	void updateStore_shouldSucceed() {
 		// given
-		Long userId = 1L;
-		User user = mock(User.class);
 		when(user.getId()).thenReturn(userId);
-
-		Long storeId = 3L;
-		Store store = mock(Store.class);
 		when(store.getUser()).thenReturn(user);
-
-		UserAuth userAuth = mock(UserAuth.class);
 		when(userAuth.getId()).thenReturn(userId);
-
-		Long categoryId = 5L;
-		Category category = mock(Category.class);
 
 		StoreUpdateRequest request = mock(StoreUpdateRequest.class);
 		when(request.categoryId()).thenReturn(categoryId);
@@ -281,20 +220,13 @@ class StoreServiceTest {
 
 		// then
 		verify(store, times(1)).update(request, category);
-
 	}
 
 	@Test
 	void updateStore_whenNotFoundCategory_shouldThrowException() {
 		// given
-		Long storeId = 3L;
-
-		UserAuth userAuth = mock(UserAuth.class);
-
-		Long categoryId = 5L;
 		StoreUpdateRequest request = mock(StoreUpdateRequest.class);
 		when(request.categoryId()).thenReturn(categoryId);
-
 		when(categoryRepository.findById(any())).thenReturn(Optional.empty());
 
 		// when & then
@@ -307,13 +239,6 @@ class StoreServiceTest {
 	@Test
 	void updateStore_whenNotFoundStore_shouldThrowException() {
 		// given
-		Long storeId = 1L;
-
-		UserAuth userAuth = mock(UserAuth.class);
-
-		Long categoryId = 5L;
-		Category category = mock(Category.class);
-
 		StoreUpdateRequest request = mock(StoreUpdateRequest.class);
 		when(request.categoryId()).thenReturn(categoryId);
 
@@ -330,20 +255,9 @@ class StoreServiceTest {
 	@Test
 	void updateStore_whenStoreOwnerMismatch_shouldThrowException() {
 		// given
-		Long ownerId = 1L;
-		User user = mock(User.class);
 		when(user.getId()).thenReturn(ownerId);
-
-		Long storeId = 3L;
-		Store store = mock(Store.class);
 		when(store.getUser()).thenReturn(user);
-
-		Long userId = 4L;
-		UserAuth userAuth = mock(UserAuth.class);
 		when(userAuth.getId()).thenReturn(userId);
-
-		Long categoryId = 5L;
-		Category category = mock(Category.class);
 
 		StoreUpdateRequest request = mock(StoreUpdateRequest.class);
 		when(request.categoryId()).thenReturn(categoryId);
@@ -361,10 +275,6 @@ class StoreServiceTest {
 	@Test
 	void deleteStore_whenStoreNotFound_shouldThrowException() {
 		// given
-		Long storeId = 10L;
-
-		UserAuth userAuth = mock(UserAuth.class);
-
 		when(storeRepository.findByIdAndDeletedDateIsNull(storeId)).thenReturn(Optional.empty());
 
 		// when & then
@@ -377,15 +287,9 @@ class StoreServiceTest {
 	@Test
 	void deleteStore_whenStoreOwnerMismatch_shouldThrowException() {
 		// given
-		Long userId = 1L;
-		UserAuth userAuth = mock(UserAuth.class);
 		when(userAuth.getId()).thenReturn(userId);
-
-		Long ownerId = 3L;
-		User owner = mock(User.class);
 		when(owner.getId()).thenReturn(ownerId);
 
-		Long storeId = 10L;
 		Store store = mock(Store.class);
 		when(store.getUser()).thenReturn(owner);
 
@@ -396,6 +300,32 @@ class StoreServiceTest {
 			() -> storeService.deleteStore(userAuth, storeId));
 
 		assertThat(STORE_OWNER_MISMATCH.getMessage()).isEqualTo(exception.getErrorCode().getMessage());
+	}
+
+	@Test
+	void getStore_whenNotFoundCategory_shouldThrowException() {
+		// given
+		SortType sortType = SortType.RATING;
+
+		when(categoryRepository.findById(any())).thenReturn(Optional.empty());
+
+		// when & then
+		BizException exception = assertThrows(BizException.class,
+			() -> storeService.getStore(sortType, categoryId, 1L, 10));
+
+		assertThat(CATEGORY_NOT_FOUND.getMessage()).isEqualTo(exception.getErrorCode().getMessage());
+	}
+
+	@Test
+	void getStoreInfo_whenStoreNotFound_shouldThrowException() {
+		// given
+		when(storeRepository.findByIdAndDeletedDateIsNull(storeId)).thenReturn(Optional.empty());
+
+		// when & then
+		BizException exception = assertThrows(BizException.class,
+			() -> storeService.getStoreInfo(storeId));
+
+		assertThat(STORE_NOT_FOUND.getMessage()).isEqualTo(exception.getErrorCode().getMessage());
 	}
 
 }

--- a/src/test/java/com/example/dishpatch/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/example/dishpatch/domain/store/service/StoreServiceTest.java
@@ -311,7 +311,7 @@ class StoreServiceTest {
 
 		// when & then
 		BizException exception = assertThrows(BizException.class,
-			() -> storeService.getStore(sortType, categoryId, 1L, 10));
+			() -> storeService.getStore(categoryId, 1L, 10));
 
 		assertThat(CATEGORY_NOT_FOUND.getMessage()).isEqualTo(exception.getErrorCode().getMessage());
 	}


### PR DESCRIPTION
## 작업내용
- 가게, 메뉴 검색 api 구현했습니다. queryDSL 사용해서 검색 키워드가 가게이름이나 메뉴이름에 포함된 가게와 메뉴 리스트를 반환해줍니다. 
- redis를 사용해서 인기검색어 조회 api를 구현했습니다. 인기검색어 순위는 매 시간의 정각에 업데이트되고, 최근 1시간 동안 가장 많이 검색된 키워드 순으로 반환하도록 구현했습니다.
- 조회 빈도 수가 높을 것 같은 카테고리별 가게 조회의 첫페이지에만 캐싱을 적용했습니다.

## 변경사항
- 카테고리별 조회 api에만 캐싱을 적용하기 위해 추천 가게 조회 api와 카테고리별 조회 api를 분리했습니다.

## 팀원에게 전할 말

## 체크 리스트
- [ ] 테스트 코드 작성
- [x] 포스트맨 확인
